### PR TITLE
reorder backend server routes and rename api endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,11 +5,8 @@ var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 var cors = require("cors");
 
-var indexRouter = require('./routes/index');
-var usersRouter = require('./routes/users');
 var testAPIRouter = require("./routes/test1");
 var customPage = require("./routes/custom");
-
 
 var app = express();
 
@@ -24,18 +21,17 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
-if (process.env.NODE_ENV === 'production') {
-  // Serve any static files
-  app.use(express.static(path.join(__dirname, 'client/build')));
-// Handle React routing, return all requests to React app
-  app.get('*', function(req, res) {
-    res.sendFile(path.join(__dirname, 'client/build', 'index.html'));
-  });
-}
-app.use('/', testAPIRouter);
+app.use('/api', testAPIRouter);
 app.use('/con', customPage);
-//app.use("/testAPI", testAPIRouter);
-//app.use(express.static(path.join(__dirname, "client", "build")))
+
+// Serve any static files
+app.use(express.static(path.join(__dirname, 'client/build')));
+
+// Handle React routing, return all requests to React app
+app.get('*', function(req, res) {
+  res.sendFile(path.join(__dirname, 'client/build', 'index.html'));
+});
+
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {
   next(createError(404));

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,12 +1,7 @@
 import React, { Component } from "react";
-import logo from "./logo.svg";
-import ReactDOM from "react-dom";
-import { createBrowserHistory } from '../node_modules/history';
-
-
-
 import "./App.css";
-var url = "/"
+
+var url = "/api"
 
 class App extends Component {
     constructor(props) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "heroku-postbuild": "cd client && npm install --only=dev && npm install && npm run build"
+    "heroku-postbuild": "cd client && npm install && npm install && npm run build"
   },
   "dependencies": {
     "cookie-parser": "~1.4.4",


### PR DESCRIPTION
So the reason it wasn't working before is because this code block was catching all requests back to the backend and rerouting it to `index.html`:

```
if (process.env.NODE_ENV === 'production') {
  // Serve any static files
  app.use(express.static(path.join(__dirname, 'client/build')));
// Handle React routing, return all requests to React app
  app.get('*', function(req, res) {
    res.sendFile(path.join(__dirname, 'client/build', 'index.html'));
  });
}
```

The `app.get('*')` was catching all get requests and rerouting them, so they never hit your `app.use('/', testAPIRouter)` line.

And the reason it worked locally is because the `if (process.env.NODE_ENV === 'production')` prevented it from being run locally. So I removed the `if` statement and moved it to below your `app.use('/', testAPIRouter)` so that it can be run locally as well.

Also, I renamed `app.use('/', testAPIRouter)` to `app.use('/api', testAPIRouter)` because the `/` was causing some issues.

I also got rid of some unneeded code.

So once you merge this is and run `git push heroku master`, it will work.